### PR TITLE
Bump package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@trello-mcp/server",
-    "version": "0.1.0",
+    "version": "0.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@trello-mcp/server",
-            "version": "0.1.0",
+            "version": "0.3.1",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@xenral/trello-mcp",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Model Context Protocol (MCP) server for Trello integration",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- bump version to 0.3.1 to avoid npm publish errors

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*